### PR TITLE
Fix args/kwargs slurps into parametric types

### DIFF
--- a/src/QuickTypes.jl
+++ b/src/QuickTypes.jl
@@ -200,8 +200,8 @@ function qexpansion(def, mutable, fully_parametric, narrow_types)
         if slurp
             @assert arg_type == :Any "Slurping with type arguments not supported"
             @assert default === nothing "Slurping with default not supported"
-            arg_type = @q(Vector{Pair})
-            push!(new_args, @q(collect(Pair, $arg_name)))
+            arg_type = Base.Iterators.Pairs
+            push!(new_args, arg_name)
             push!(constr_kwargs, kwarg)
             push!(o_constr_kwargs, kwarg)
         else

--- a/src/QuickTypes.jl
+++ b/src/QuickTypes.jl
@@ -174,14 +174,15 @@ function qexpansion(def, mutable, fully_parametric, narrow_types)
             @assert default === nothing "Slurping with default not supported"
             arg_type = :Tuple
             push!(constr_args, arg)
+            push!(o_constr_args, arg)
         else
             push!(constr_args,
                   default === nothing ? arg_name : Expr(:kw, arg_name, default))
+            push!(o_constr_args, arg_name)
         end
         push!(fields, @q($arg_name::$arg_type))
         push!(new_args, arg_name)
         push!(arg_names, arg_name)
-        push!(o_constr_args, arg_name)
     end
     # Parse keyword-arguments
     define_show = nothing # see after the loop
@@ -202,15 +203,16 @@ function qexpansion(def, mutable, fully_parametric, narrow_types)
             arg_type = @q(Vector{Pair})
             push!(new_args, @q(collect(Pair, $arg_name)))
             push!(constr_kwargs, kwarg)
+            push!(o_constr_kwargs, kwarg)
         else
             push!(new_args, arg_name)
             push!(constr_kwargs,
                   default === nothing ? arg_name : Expr(:kw, arg_name, default))
+            push!(o_constr_kwargs, Expr(:kw, arg_name, arg_name))
         end
         push!(reg_kwargs, kwarg)
         push!(kwfields, @q($arg_name::$arg_type))
         push!(arg_names, arg_name)
-        push!(o_constr_kwargs, Expr(:kw, arg_name, arg_name))
     end
     # By default, only define Base.show when there are keyword arguments --- otherwise
     # the native `show` is perfectly sufficient.

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -76,6 +76,14 @@ let
     @test y == 1
 end
 
+# Slurping (parametric case)
+
+@qstruct SlurpParam{T}(x::AbstractVector{T}, y=1, args...; kwargs...)
+s = SlurpParam([1,2,3,4,5,6,7], 8, 9,10; x=1, y=10+2)
+@test s.args == (9,10)
+@test s.kwargs == [(:x => 1), (:y => 12)]
+
+
 ################################################################################
 
 @qmutable Foo{T}(x::T; y=2) do

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -64,7 +64,7 @@ o2 = @inferred setproperties(o, (x=:five, y=100.0))
 @qstruct Slurp(x, y=1, args...; kwargs...)
 s = Slurp(1,2,3,4,5,6,7; x=1, y=10+2)
 @test s.args == (3,4,5,6,7)
-@test s.kwargs == [(:x => 1), (:y => 12)]
+@test s.kwargs == pairs((x=1, y=12))
 s2 = @inferred setproperties(s, x=:hello)
 @test s2 isa Slurp
 @test s2.x == :hello
@@ -81,7 +81,7 @@ end
 @qstruct SlurpParam{T}(x::AbstractVector{T}, y=1, args...; kwargs...)
 s = SlurpParam([1,2,3,4,5,6,7], 8, 9,10; x=1, y=10+2)
 @test s.args == (9,10)
-@test s.kwargs == [(:x => 1), (:y => 12)]
+@test s.kwargs == pairs((x=1, y=12))
 
 
 ################################################################################


### PR DESCRIPTION
so that e.g.

```jl
using QuickTypes: @qstruct

@qstruct Stuff{T}(data::AbstractVector{T}; flag=true, kwargs...)

a = Stuff(["a", "b", "c"], allo="hello")
aa = Stuff(a.data; one="more", a.kwargs...)
extra = (;yo="yoyo", a.kwargs..., aa.kwargs...)
```

gives:

```jl
julia> extra
(yo = "yoyo", one = "more", allo = "hello", more = "again", hello = "allo")
```

instead of

```jl
julia> extra
(yo = "yoyo", kwargs = Base.Iterators.Pairs{Symbol,Any,Tuple{Symbol,Symbol},NamedTuple{(:one, :kwargs),Tuple{String,Base.Iterators.Pairs{Symbol,String,Tuple{Symbol},NamedTuple{(:allo,),Tuple{String}}}}}}(:one => "more",:kwargs => Base.Iterators.Pairs(:allo => "hello")))
```