### PR TITLE
Functor printing

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "QuickTypes"
 uuid = "ae2dfa86-617c-530c-b392-ef20fdad97bb"
-version = "1.7.0"
+version = "1.8.0"
 
 [deps]
 ConstructionBase = "187b0558-2788-49d3-abe0-74a17ed4e7c9"

--- a/Project.toml
+++ b/Project.toml
@@ -9,7 +9,7 @@ MacroTools = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
 [compat]
 ConstructionBase = "1"
 MacroTools = "0.5"
-julia = "1.3"
+julia = "1.7"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/src/QuickTypes.jl
+++ b/src/QuickTypes.jl
@@ -377,6 +377,12 @@ end
 ################################################################################
 # @qfunctor
 
+""" Abstract type for qfunctors. Was introduced to improve printing of QFunctor """
+abstract type QFunctor <: Function end
+
+Base.show(io::IO, mime::MIME"text/plain", qf::QFunctor) =
+    Base.@invoke(Base.show(io::typeof(io), mime::typeof(mime), qf::Any))
+
 """
 ```julia
 @qfunctor function Action(verb::Symbol)(what)
@@ -402,7 +408,7 @@ macro qfunctor(fdef0)
         fdef = A
     else
         fdef = fdef0
-        parenttype = :($Base.Function)
+        parenttype = :($QFunctor)
     end
     di = splitdef(fdef)
     type_def = di[:name]

--- a/src/QuickTypes.jl
+++ b/src/QuickTypes.jl
@@ -138,7 +138,7 @@ narrow_typeof(t::T) where {T} = T
 
 # Helper for @qmutable/@qstruct
 # narrow_types means that
-function qexpansion(def, mutable, fully_parametric, narrow_types)
+function qexpansion(def::Expr, mutable::Bool, fully_parametric::Bool, narrow_types::Bool)
     if !@capture(def, typ_def_ <: parent_type_)
         typ_def = def
         parent_type = :Any

--- a/src/QuickTypes.jl
+++ b/src/QuickTypes.jl
@@ -381,6 +381,9 @@ end
 abstract type QFunctor <: Function end
 
 Base.show(io::IO, mime::MIME"text/plain", qf::QFunctor) =
+    # Without this method, functors print like functions, i.e.
+    #     (::Foo) (generic function with 1 methods)
+    # which is bothersome because the fields don't show up.
     Base.@invoke(Base.show(io::typeof(io), mime::typeof(mime), qf::Any))
 
 """

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -139,6 +139,11 @@ end
 
 @qfunctor ParamAction{X}(a::X)(b::T) where T = (a, b, X, T)
 @test ParamAction(1)(2.0) == (1, 2.0, Int, Float64)
+@test string(ParamAction(1)) == "ParamAction{Int64}(1)"
+
+io = IOBuffer();
+show(io, MIME"text/plain"(), ParamAction(1))
+@test String(take!(io)) == "ParamAction{Int64}(1)"
 
 ################################################################################
 # @destruct


### PR DESCRIPTION
Not crazy about this implementation, but it's probably alright. The alternative would be to set `_define_show=true`, which is messy.

I'm not exporting QFunctor, which gives me some lee-way in case I want to go back.